### PR TITLE
FIX: Fix Microsoft connector and adjust workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Calculate Docker image tags
         id: tags
         env:
-          DOCKER_IMAGES: "ghcr.io/dexidp/dex dexidp/dex"
+          DOCKER_IMAGES: "ghcr.io/schuhu/dex"
         run: |
           case $GITHUB_REF in
             refs/tags/*)  VERSION=${GITHUB_REF#refs/tags/};;
@@ -64,12 +64,12 @@ jobs:
           password: ${{ github.token }}
         if: github.event_name == 'push'
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-        if: github.event_name == 'push'
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      #   if: github.event_name == 'push'
 
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/connector/microsoft/microsoft.go
+++ b/connector/microsoft/microsoft.go
@@ -32,11 +32,11 @@ const (
 )
 
 const (
-	// Microsoft requires this scope to access user's profile
-	scopeUser = "user.read"
-	// Microsoft requires this scope to list groups the user is a member of
-	// and resolve their ids to groups names.
-	scopeGroups = "directory.read.all"
+	// Microsoft requires the scopes to start with openid
+	scopeOpenID = "openid"
+	// Get the permissions configured on the application registration
+	// see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent#the-default-scope
+	scopeDefault = "https://graph.microsoft.com/.default"
 	// Microsoft requires this scope to return a refresh token
 	// see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent#offline_access
 	scopeOfflineAccess = "offline_access"
@@ -130,10 +130,8 @@ func (c *microsoftConnector) groupsRequired(groupScope bool) bool {
 }
 
 func (c *microsoftConnector) oauth2Config(scopes connector.Scopes) *oauth2.Config {
-	microsoftScopes := []string{scopeUser}
-	if c.groupsRequired(scopes.Groups) {
-		microsoftScopes = append(microsoftScopes, scopeGroups)
-	}
+	microsoftScopes := []string{scopeOpenID}
+	microsoftScopes = append(microsoftScopes, scopeDefault)
 
 	if scopes.OfflineAccess {
 		microsoftScopes = append(microsoftScopes, scopeOfflineAccess)


### PR DESCRIPTION
Overview
This PR adds the openid scope necessary for the Microsoft Identity Platform v2 as well as changes the user and group scopes to the ones now supported on the Microsoft graph API.
This PR was created together with Microsoft backend engineers and fixes #1855

What this PR does / why we need it
The current Microsoft connector just works. But if you enabled features like 2fa on your Microsoft Azure AD Application this is not enforced, because the scopes used trigger the Azure App in a different way than intended.

So, to be able to use 2fa on a Microsoft Azure AD App, you need those changes.

Special notes for your reviewer
I tested this change locally with group sync and refresh token. Same behaviour as before, except that policies like 2fa applied to the Azure AD App now are enforced by Microsoft.

Does this PR introduce a user-facing change?
NONE